### PR TITLE
Update README.md with correct --bind option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains **Dockerfile** of [RethinkDB](http://www.rethinkdb.com/
 
 #### Run the first host of cluster
 
-    docker run -d -p 8080:8080 -p 28015:28015 -p 29015:29015 -v <data-dir>:/data dockerfile/rethinkdb rethinkdb --bind=all --canonical-address `curl -s ipecho.net/plain` --machine-name `hostname | sed 's/-/_/g'`
+    docker run -d -p 8080:8080 -p 28015:28015 -p 29015:29015 -v <data-dir>:/data dockerfile/rethinkdb rethinkdb --bind all --canonical-address `curl -s ipecho.net/plain` --machine-name `hostname | sed 's/-/_/g'`
 
 #### Run subsequent hosts joining to cluster
 


### PR DESCRIPTION
Example for running the first host of the cluster has `--bind=all`, which will give `Error in the command line: Unrecognized option '--bind=all'.`. The correct formatting is `--bind all`.
