### PR TITLE
specify rethinkdb version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   apt-get update && \
 ## Use this to find the right version name (i.e. "1.14.0-0ubuntu1~trusty")
 #  apt-cache showpkg rethinkdb && \
-  apt-get install -y rethinkdb=1.14.0-0ubuntu1~trusty && \
+  apt-get install -y rethinkdb=1.14.0-0ubuntu1~`lsb_release -cs` && \
   rm -rf /var/lib/apt/lists/*
 
 # Define mountable directories.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN \
   echo "deb http://download.rethinkdb.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/rethinkdb.list && \
   wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && \
   apt-get update && \
-  apt-get install -y rethinkdb && \
+## Use this to find the right version name (i.e. "1.14.0-0ubuntu1~trusty")
+#  apt-cache showpkg rethinkdb && \
+  apt-get install -y rethinkdb=1.14.0-0ubuntu1~trusty && \
   rm -rf /var/lib/apt/lists/*
 
 # Define mountable directories.


### PR DESCRIPTION
I thought it would be good to have specific versions instead of "latest"

With tag "latest" you never know what you are gonna install, so you could end up with servers or developers running either 1.13.0 or 1.14.0 given the date they issued a "docker pull ..".

Having specific versions will give developers a way to put in their readme.md of their project: `docker pull dockerfile/rethinkdb:v1.14.0`

what do you think?
