### PR TITLE
Added python driver for rethinkdb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN \
   echo "deb http://download.rethinkdb.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/rethinkdb.list && \
   wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && \
   apt-get update && \
-  apt-get install -y rethinkdb && \
+  apt-get install -y rethinkdb python-pip && \
   rm -rf /var/lib/apt/lists/*
+
+# Install python driver for rethinkdb
+RUN pip install rethinkdb
 
 # Define mountable directories.
 VOLUME ["/data"]


### PR DESCRIPTION
This enables the use of rethinkdb dump utility for making backups.

Explanation:
The `rethinkdb dump` command needs the python driver for rethinkdb to function. 
http://rethinkdb.com/docs/migration/
