### PR TITLE
Add HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN \
 # Install python driver for rethinkdb
 RUN pip install rethinkdb
 
+# Set up server health-checking script:
+COPY bin/health-check /bin/health-check
+HEALTHCHECK --interval=5s CMD /bin/health-check
+
 # Define mountable directories.
 VOLUME ["/data"]
 

--- a/bin/health-check
+++ b/bin/health-check
@@ -15,7 +15,7 @@ def is_healty():
         r.db('rethinkdb')
             .table('table_status')
             .get_field('status')
-            .map(lambda status: status.values())
+            .concat_map(lambda status: status.values())
             .reduce(r.and_)
             .default(True)
     )

--- a/bin/health-check
+++ b/bin/health-check
@@ -1,0 +1,33 @@
+#!/usr/bin/env python2
+
+import sys
+import rethinkdb as r
+
+
+def is_healty():
+    can_access_status = (
+        r.db('rethinkdb')
+            .table('server_status')
+            .nth(0)
+    )
+
+    all_tables_ready = (
+        r.db('rethinkdb')
+            .table('table_status')
+            .get_field('status')
+            .map(lambda status: status.values())
+            .reduce(r.and_)
+            .default(True)
+    )
+
+    try:
+        conn = r.connect()
+        return (can_access_status & all_tables_ready).run(conn)
+    except:
+        return False
+
+
+if is_healty():
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/bin/health-check
+++ b/bin/health-check
@@ -4,7 +4,7 @@ import sys
 import rethinkdb as r
 
 
-def is_healty():
+def is_healthy():
     can_access_status = (
         r.db('rethinkdb')
             .table('server_status')
@@ -27,7 +27,7 @@ def is_healty():
         return False
 
 
-if is_healty():
+if is_healthy():
     sys.exit(0)
 else:
     sys.exit(1)


### PR DESCRIPTION
Add a `HEALTHCHECK` to the `Dockerfile`, using a python script that checks for:

- Connectivity
- Availability of the `rethinkdb.server_status` entry
- Green status in all `status` fields for all entries in the `rethinkdb.table_status` table

I'm not sure this is the best way, but I can't find an official health checking mechanism, and this is working for me.